### PR TITLE
Products e2e add to basket tests

### DIFF
--- a/apps/api/src/app/products/products.service.spec.ts
+++ b/apps/api/src/app/products/products.service.spec.ts
@@ -5,10 +5,13 @@ import { firstValueFrom } from 'rxjs';
 import { products } from './products.constant';
 import { ProductsService as Service } from './products.service';
 
+// set the timeout to cover request that take longer to perform
+jest.setTimeout(30000);
+
 // Declare the mock of the HttpModule dependency, axios
 jest.mock('axios');
 
-describe('Persons Service', () => {
+describe('Products Service', () => {
   // Reference variables used for spying
   let service: Service;
   let httpService: HttpService;

--- a/apps/teststore-e2e/src/integration/products-page.spec.ts
+++ b/apps/teststore-e2e/src/integration/products-page.spec.ts
@@ -83,13 +83,12 @@ describe('Products Page E2E UI Tests', () => {
   });
 
   it('should display an alert when the user tries to add product items to the basket totalling over 666666 in price', () => {
-    // Set the product items to session storage to a single product with a fake price that is right at the limit of 666666
+    // Create the list of items that totals 666.993,33 in price
+    const basketItems = Array(666).fill(products[13]); // products[13] corresponds to the item with the highest price of 999,99
+    // Set the product items to session storage to a list of items that is right at the limit of 666666
     // Get the session stroage from the actual browser instance window (the cypress instance has its own session storage independant from the test window)
     cy.window().then((window) => {
-      window.sessionStorage.setItem(
-        'basket',
-        JSON.stringify([{ price: 666665 }])
-      );
+      window.sessionStorage.setItem('basket', JSON.stringify(basketItems));
       cy.spy(window, 'alert').as('alert');
     });
     // Validate the text of the alert.
@@ -99,7 +98,7 @@ describe('Products Page E2E UI Tests', () => {
     });
     // Add an extra product, going over the total price limit and triggering an alert
     cy.get('[data-cy=products-product-item-add-to-basket-btn]')
-      .first()
+      .eq(13) // corresponds to products[14] aka the most expensive item
       .click()
       .then(() => {
         cy.get('@alert').should('have.been.calledOnce');

--- a/apps/teststore-e2e/src/integration/products-page.spec.ts
+++ b/apps/teststore-e2e/src/integration/products-page.spec.ts
@@ -7,6 +7,10 @@ describe('Products Page E2E UI Tests', () => {
       body: products,
       statusCode: 200,
     });
+    // Clear session storage of the actual test instance
+    cy.window().then((window) => {
+      window.sessionStorage.clear();
+    });
     cy.visit('/products');
   });
 
@@ -52,5 +56,53 @@ describe('Products Page E2E UI Tests', () => {
       .first()
       .contains('Add to basket')
       .should('be.visible');
+  });
+
+  it('should add the product item to session storage when the add to basket button is pressed', () => {
+    cy.url().should('include', '/products');
+    // Add an item to basket aka sessionStorage
+    cy.get('[data-cy=products-product-item-add-to-basket-btn]').first().click();
+
+    // Get the session stroage from the actual browser instance window (the cypress instance has its own session storage independant from the test window)
+    cy.window().then((window) => {
+      const itemsInSessionStorage = JSON.parse(
+        window.sessionStorage.getItem('basket') || '[]'
+      );
+      expect(itemsInSessionStorage.length).equal(1);
+    });
+
+    // Add two more item to basket aka sessionStorage
+    cy.get('[data-cy=products-product-item-add-to-basket-btn]').first().click();
+    cy.get('[data-cy=products-product-item-add-to-basket-btn]').first().click();
+    cy.window().then((window) => {
+      const itemsInSessionStorage = JSON.parse(
+        window.sessionStorage.getItem('basket') || '[]'
+      );
+      expect(itemsInSessionStorage.length).equal(3);
+    });
+  });
+
+  it('should display an alert when the user tries to add product items to the basket totalling over 666666 in price', () => {
+    // Set the product items to session storage to a single product with a fake price that is right at the limit of 666666
+    // Get the session stroage from the actual browser instance window (the cypress instance has its own session storage independant from the test window)
+    cy.window().then((window) => {
+      window.sessionStorage.setItem(
+        'basket',
+        JSON.stringify([{ price: 666665 }])
+      );
+      cy.spy(window, 'alert').as('alert');
+    });
+    // Validate the text of the alert.
+    // Does not validate that the alert appears
+    cy.on('window:alert', (text) => {
+      expect(text).to.contains('You have exceeded the maximum purchase amount');
+    });
+    // Add an extra product, going over the total price limit and triggering an alert
+    cy.get('[data-cy=products-product-item-add-to-basket-btn]')
+      .first()
+      .click()
+      .then(() => {
+        cy.get('@alert').should('have.been.calledOnce');
+      });
   });
 });

--- a/apps/teststore-e2e/src/integration/products-page.spec.ts
+++ b/apps/teststore-e2e/src/integration/products-page.spec.ts
@@ -101,7 +101,14 @@ describe('Products Page E2E UI Tests', () => {
       .eq(13) // corresponds to products[14] aka the most expensive item
       .click()
       .then(() => {
+        // Assert that the alert was shown
         cy.get('@alert').should('have.been.calledOnce');
+
+        // Check that no extra items were added to the basket
+        const itemsInSessionStorage = JSON.parse(
+          window.sessionStorage.getItem('basket') || '[]'
+        );
+        expect(itemsInSessionStorage.length).equal(666);
       });
   });
 });

--- a/apps/teststore/src/app/products/products.component.ts
+++ b/apps/teststore/src/app/products/products.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { IProduct } from '@interfaces';
+import { PriceCalculationService } from '../shared/services/price-calculation.service';
 import { ProductsService } from '../shared/services/products.service';
 
 @Component({
@@ -10,7 +11,10 @@ import { ProductsService } from '../shared/services/products.service';
 export class ProductsComponent implements OnInit {
   productsList: IProduct[] = [];
 
-  constructor(private productsService: ProductsService) {}
+  constructor(
+    private productsService: ProductsService,
+    private priceCalculationService: PriceCalculationService
+  ) {}
 
   ngOnInit(): void {
     this.productsService.getAll().subscribe({
@@ -34,6 +38,12 @@ export class ProductsComponent implements OnInit {
       productsInBasket = JSON.parse(sessionStorageItems);
     }
     productsInBasket.push(product);
-    sessionStorage.setItem('basket', JSON.stringify(productsInBasket));
+    if (
+      this.priceCalculationService.calculateSubtotal(productsInBasket) > 666666
+    ) {
+      alert('You have exceeded the maximum purchase amount');
+    } else {
+      sessionStorage.setItem('basket', JSON.stringify(productsInBasket));
+    }
   }
 }


### PR DESCRIPTION
Add the two missing complex test cases:
- While on the ‘/products’ route When the User presses an ‘add to basket’ button on the first product item Then the item object is added to the session storage of the browser.
- While on the ‘/products’ route When the User presses an ‘add to basket’ button on the product item with the highest price (999.99) 667 times Then an alert is shown with text “You have exceeded the maximum purchase amount” and the session storage only contains 666 items.

Session storage is access by accessing the inner window object of the given test instance.
```ts
    cy.window().then((window) => {
      window.sessionStorage.setItem('basket', JSON.stringify(basketItems));
    });
```
if just `sessionstorage.setItem(...)` etc are used then it will refer to the cypress run container session storage, which is not affected by the running test.
