### PR TITLE
Add products and discount E2E UI tests

### DIFF
--- a/apps/teststore-e2e/src/integration/checkout/checkout-page.spec.ts
+++ b/apps/teststore-e2e/src/integration/checkout/checkout-page.spec.ts
@@ -1,0 +1,18 @@
+describe('Checkout page E2E UI Tests', () => {
+  beforeEach(() => {
+    cy.visit('/checkout');
+  });
+
+  describe('Checkout page load', () => {
+    it('should have the correct URL', () => {
+      cy.visit('/products');
+      cy.visit('/checkout');
+      cy.url().should('include', '/checkout');
+    });
+
+    it('should show the Checkout text', () => {
+      cy.url().should('include', '/checkout');
+      cy.get('[data-cy=header-checkout]').contains('Checkout');
+    });
+  });
+});

--- a/apps/teststore-e2e/src/integration/checkout/discount.ts
+++ b/apps/teststore-e2e/src/integration/checkout/discount.ts
@@ -37,41 +37,35 @@ describe('Checkout page E2E UI Tests', () => {
       );
     });
 
+    it('should disable the apply button when the discount contains invalid characters', () => {
+      // Validate input field colors for invalid text
+      cy.get('[data-cy=checkout-discount-input]')
+        .should('have.css', 'background-color', 'rgb(255, 255, 255)')
+        .type('ExampleDiscount#')
+        .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+        .clear()
+        .type('ExampleDiscount!')
+        .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+        .clear()
+        .type('ExampleDiscount*')
+        .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+        .clear();
+      // Validate the text of the alert.
+      // Does not validate that the alert appears
+      cy.on('window:alert', (text) => {
+        expect(text).to.contains('Discount Invalid');
+      });
+      // Try to apply an invalid discount
+      cy.get('[data-cy=checkout-discount-input]').type('ExampleDiscount*');
+      cy.get('[data-cy=checkout-discount-apply-btn]').should('be.disabled');
+    });
+
     describe('should display an alert to the user and clear any discount information when', () => {
       beforeEach(() => {
         // Create a reference to the alert
         cy.window().then((window) => {
           cy.spy(window, 'alert').as('alert');
         });
-      });
-
-      it('the discount contains invalid characters', () => {
-        // Validate input field colors for invalid text
-        cy.get('[data-cy=checkout-discount-input]')
-          .should('have.css', 'background-color', 'rgb(255, 255, 255)')
-          .type('ExampleDiscount#')
-          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
-          .clear()
-          .type('ExampleDiscount!')
-          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
-          .clear()
-          .type('ExampleDiscount*')
-          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
-          .clear();
-        // Validate the text of the alert.
-        // Does not validate that the alert appears
-        cy.on('window:alert', (text) => {
-          expect(text).to.contains('Discount Invalid');
-        });
-        // Try to apply an invalid discount
-        cy.get('[data-cy=checkout-discount-input]').type('ExampleDiscount*');
-        cy.get('[data-cy=checkout-discount-apply-btn]')
-          .click()
-          .then(() => {
-            // TODO - figure out if the alert should show or if the button should be disabled
-            // Assert that the alert was shown
-            cy.get('@alert').should('have.been.called');
-          });
       });
 
       it(`the discount has no remaning uses`, () => {

--- a/apps/teststore-e2e/src/integration/checkout/discount.ts
+++ b/apps/teststore-e2e/src/integration/checkout/discount.ts
@@ -1,0 +1,47 @@
+import { products } from '../../fixtures/products.constant';
+
+describe('Checkout page E2E UI Tests', () => {
+  beforeEach(() => {
+    // Clear session storage of the actual test instance
+    cy.window().then((window) => {
+      window.sessionStorage.clear();
+    });
+    // Set session storage basket to containt wo different products
+    // Get the session stroage from the actual browser instance window (the cypress instance has its own session storage independant from the test window)
+    cy.window().then((window) => {
+      window.sessionStorage.setItem(
+        'basket',
+        JSON.stringify([products[0], products[1]])
+      );
+    });
+    cy.visit('/checkout');
+  });
+
+  describe('Discount section', () => {
+    it(`should contain an input field with a placeholder and a label, and pricing information includes ´You Save: 0 DKK´`, () => {
+      cy.get('[data-cy=checkout-discount-input]').should(
+        'have.attr',
+        'placeholder',
+        'ExampleDiscount'
+      );
+    });
+
+    describe('should display an alert ot the user and clear any discount information when', () => {
+      it('the discount contains invalid characters', () => {});
+
+      it(`the discount has no remaning uses`, () => {});
+
+      it(`the discount isn't active yet`, () => {});
+
+      it(`the discount is expired`, () => {});
+
+      it(`the discount isn't enabled`, () => {});
+
+      it(`the discount doesn't exist in the database`, () => {});
+    });
+
+    it('should display an alert and update the pricing information when valid discount is inputted', () => {});
+
+    it('should clear any discount information when a invalid discount is applied after a sucecssful one', () => {});
+  });
+});

--- a/apps/teststore-e2e/src/integration/checkout/discount.ts
+++ b/apps/teststore-e2e/src/integration/checkout/discount.ts
@@ -1,4 +1,15 @@
+import { DiscountTypeEnum, IDiscount } from '@interfaces';
 import { products } from '../../fixtures/products.constant';
+
+const mockDiscount: IDiscount = {
+  discountId: '',
+  code: '',
+  amount: 100,
+  type: DiscountTypeEnum.amount,
+  remainingUses: 100,
+  startsAt: new Date(),
+  isEnabled: true,
+};
 
 describe('Checkout page E2E UI Tests', () => {
   beforeEach(() => {
@@ -26,22 +37,273 @@ describe('Checkout page E2E UI Tests', () => {
       );
     });
 
-    describe('should display an alert ot the user and clear any discount information when', () => {
-      it('the discount contains invalid characters', () => {});
+    describe('should display an alert to the user and clear any discount information when', () => {
+      beforeEach(() => {
+        // Create a reference to the alert
+        cy.window().then((window) => {
+          cy.spy(window, 'alert').as('alert');
+        });
+      });
 
-      it(`the discount has no remaning uses`, () => {});
+      it('the discount contains invalid characters', () => {
+        // Validate input field colors for invalid text
+        cy.get('[data-cy=checkout-discount-input]')
+          .should('have.css', 'background-color', 'rgb(255, 255, 255)')
+          .type('ExampleDiscount#')
+          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+          .clear()
+          .type('ExampleDiscount!')
+          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+          .clear()
+          .type('ExampleDiscount*')
+          .should('have.css', 'background-color', 'rgb(255, 204, 203)')
+          .clear();
+        // Validate the text of the alert.
+        // Does not validate that the alert appears
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Try to apply an invalid discount
+        cy.get('[data-cy=checkout-discount-input]').type('ExampleDiscount*');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // TODO - figure out if the alert should show or if the button should be disabled
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+      });
 
-      it(`the discount isn't active yet`, () => {});
+      it(`the discount has no remaning uses`, () => {
+        // Create a startsAt date for the mock
+        const startsAtDate = new Date();
+        startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+        // Mock the API call for applying the discount
+        cy.intercept('GET', '/api/discounts/*', {
+          body: { ...mockDiscount, startsAt: startsAtDate, remainingUses: 0 },
+          statusCode: 200,
+        });
+        // Validate the alert contents
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Apply the discount
+        cy.get('[data-cy=checkout-discount-input]').type('UsedUpDiscount');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+        // Validate that the pricing information contain valid discount information
+        cy.get('[data-cy=checkout-order-price-you-save]').should(
+          'contain',
+          'You save: 0.00 DKK'
+        );
+      });
 
-      it(`the discount is expired`, () => {});
+      it(`the discount isn't active yet`, () => {
+        // Create a startsAt date for the mock
+        const startsAtDate = new Date();
+        startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+        // Mock the API call for applying the discount
+        cy.intercept('GET', '/api/discounts/*', {
+          body: { ...mockDiscount, startsAt: startsAtDate },
+          statusCode: 200,
+        });
+        // Validate the alert contents
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Apply the discount
+        cy.get('[data-cy=checkout-discount-input]').type('InvactiveDiscount');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+        // Validate that the pricing information contain valid discount information
+        cy.get('[data-cy=checkout-order-price-you-save]').should(
+          'contain',
+          'You save: 0.00 DKK'
+        );
+      });
 
-      it(`the discount isn't enabled`, () => {});
+      it(`the discount is expired`, () => {
+        // Create a startsAt date for the mock
+        const startsAtDate = new Date();
+        startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+        // Mock the API call for applying the discount
+        cy.intercept('GET', '/api/discounts/*', {
+          body: {
+            ...mockDiscount,
+            startsAt: startsAtDate,
+            expiresAt: startsAtDate,
+          },
+          statusCode: 200,
+        });
+        // Validate the alert contents
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Apply the discount
+        cy.get('[data-cy=checkout-discount-input]').type('ExpiredDiscount');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+        // Validate that the pricing information contain valid discount information
+        cy.get('[data-cy=checkout-order-price-you-save]').should(
+          'contain',
+          'You save: 0.00 DKK'
+        );
+      });
 
-      it(`the discount doesn't exist in the database`, () => {});
+      it(`the discount isn't enabled`, () => {
+        // Create a startsAt date for the mock
+        const startsAtDate = new Date();
+        startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+        // Mock the API call for applying the discount
+        cy.intercept('GET', '/api/discounts/*', {
+          body: { ...mockDiscount, startsAt: startsAtDate, isEnabled: false },
+          statusCode: 200,
+        });
+        // Validate the alert contents
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Apply the discount
+        cy.get('[data-cy=checkout-discount-input]').type('DisabledDiscount');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+        // Validate that the pricing information contain valid discount information
+        cy.get('[data-cy=checkout-order-price-you-save]').should(
+          'contain',
+          'You save: 0.00 DKK'
+        );
+      });
+
+      it(`the discount doesn't exist in the database`, () => {
+        // Mock the API call for applying the discount
+        cy.intercept('GET', '/api/discounts/*', {
+          statusCode: 404,
+        });
+        // Validate the alert contents
+        cy.on('window:alert', (text) => {
+          expect(text).to.contains('Discount Invalid');
+        });
+        // Apply the discount
+        cy.get('[data-cy=checkout-discount-input]').type('NonexistentDiscount');
+        cy.get('[data-cy=checkout-discount-apply-btn]')
+          .click()
+          .then(() => {
+            // Assert that the alert was shown
+            cy.get('@alert').should('have.been.called');
+          });
+        // Validate that the pricing information contain valid discount information
+        cy.get('[data-cy=checkout-order-price-you-save]').should(
+          'contain',
+          'You save: 0.00 DKK'
+        );
+      });
     });
 
-    it('should display an alert and update the pricing information when valid discount is inputted', () => {});
+    it('should display an alert and update the pricing information when valid discount is inputted', () => {
+      // Create a reference to the alert
+      cy.window().then((window) => {
+        cy.spy(window, 'alert').as('alert');
+      });
 
-    it('should clear any discount information when a invalid discount is applied after a sucecssful one', () => {});
+      // Create a startsAt date for the mock
+      const startsAtDate = new Date();
+      startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+      // Mock the API call for applying the discount
+      cy.intercept('GET', '/api/discounts/*', {
+        body: { ...mockDiscount, startsAt: startsAtDate },
+        statusCode: 200,
+      });
+      cy.on('window:alert', (text) => {
+        expect(text).to.contains('Discount Applied');
+      });
+      cy.get('[data-cy=checkout-discount-input]').type('ExampleDiscount');
+      cy.get('[data-cy=checkout-discount-apply-btn]')
+        .click()
+        .then(() => {
+          // Assert that the alert was shown
+          cy.get('@alert').should('have.been.called');
+        });
+      cy.get('[data-cy=checkout-order-price-you-save]').should(
+        'contain',
+        `You save: ${mockDiscount.amount}.00 DKK`
+      );
+    });
+
+    it('should clear any discount information when a invalid discount is applied after a sucecssful one', () => {
+      let testState: 'discountApplied' | 'discountInvalid' = 'discountApplied'; // Used to get a reference to the state of the test and what text the allert should have
+      // Create a reference to the alert
+      cy.window().then((window) => {
+        cy.spy(window, 'alert').as('alert');
+      });
+
+      // Create a startsAt date for the mock
+      const startsAtDate = new Date();
+      startsAtDate.setDate(new Date().getDate() - 5); // set the date to 5 days behind the current date
+      // Mock the API call for applying the discount
+      cy.intercept('GET', '/api/discounts/*', {
+        body: { ...mockDiscount, startsAt: startsAtDate },
+        statusCode: 200,
+        times: 1,
+      }).as('applyDiscountValid');
+      // Depending on in which part of the test the alert is shown, validate the alert text
+      cy.on('window:alert', (text) => {
+        expect(text).to.contains(
+          testState === 'discountApplied'
+            ? 'Discount Applied'
+            : 'Discount Invalid'
+        );
+      });
+      cy.get('[data-cy=checkout-discount-input]').type('ValidDiscount');
+      cy.get('[data-cy=checkout-discount-apply-btn]')
+        .click()
+        .then(() => {
+          // Assert that the alert was shown
+          cy.get('@alert').should('have.been.called');
+        });
+      cy.get('[data-cy=checkout-order-price-you-save]').should(
+        'contain',
+        `You save: ${mockDiscount.amount}.00 DKK`
+      );
+
+      // Apply the discount again
+      // Mock the API call for applying the discount but this time return 404
+      cy.intercept('GET', '/api/discounts/*', {
+        statusCode: 404,
+        times: 1,
+      }).as('applyDiscountInvalid');
+      cy.get('[data-cy=checkout-discount-input]')
+        .clear()
+        .type('InvalidDiscount')
+        .then(() => {
+          // Change of the state has to be set via the .then() method otherwise cypress will apply it out of order
+          testState = 'discountInvalid';
+        });
+      cy.get('[data-cy=checkout-discount-apply-btn]')
+        .click()
+        .then(() => {
+          // Assert that the alert was shown
+          cy.get('@alert').should('have.been.called');
+        });
+      cy.get('[data-cy=checkout-order-price-you-save]').should(
+        'contain',
+        `You save: 0.00 DKK`
+      );
+    });
   });
 });

--- a/apps/teststore-e2e/src/integration/checkout/email-input.spec.ts
+++ b/apps/teststore-e2e/src/integration/checkout/email-input.spec.ts
@@ -1,22 +1,6 @@
-import * as products from '../fixtures/products.constant';
-
 describe('Checkout page E2E UI Tests', () => {
   beforeEach(() => {
-    //TO DO: Set up the
     cy.visit('/checkout');
-  });
-
-  describe('Checkout page load', () => {
-    it('should have the correct URL', () => {
-      cy.visit('/products');
-      cy.visit('/checkout');
-      cy.url().should('include', '/checkout');
-    });
-
-    it('should show the Checkout text', () => {
-      cy.url().should('include', '/checkout');
-      cy.get('[data-cy=header-checkout]').contains('Checkout');
-    });
   });
 
   describe('Your email input element', () => {

--- a/apps/teststore-e2e/src/integration/checkout/products-items.spec.ts
+++ b/apps/teststore-e2e/src/integration/checkout/products-items.spec.ts
@@ -1,6 +1,6 @@
 import { products } from '../../fixtures/products.constant';
 
-describe('Checkout page E2E UI Tests', () => {
+describe('Products page E2E UI Tests', () => {
   beforeEach(() => {
     // Clear session storage of the actual test instance
     cy.window().then((window) => {

--- a/apps/teststore-e2e/src/integration/checkout/products-items.spec.ts
+++ b/apps/teststore-e2e/src/integration/checkout/products-items.spec.ts
@@ -1,0 +1,52 @@
+import { products } from '../../fixtures/products.constant';
+
+describe('Checkout page E2E UI Tests', () => {
+  beforeEach(() => {
+    // Clear session storage of the actual test instance
+    cy.window().then((window) => {
+      window.sessionStorage.clear();
+    });
+    // Set session storage basket to containt wo different products
+    // Get the session stroage from the actual browser instance window (the cypress instance has its own session storage independant from the test window)
+    cy.window().then((window) => {
+      window.sessionStorage.setItem(
+        'basket',
+        JSON.stringify([products[0], products[1]])
+      );
+    });
+    cy.visit('/checkout');
+  });
+
+  describe('Your order section', () => {
+    it('should be empty if there are no items in the basket', () => {
+      // Remove any products fromt he sessionStorage basket
+      cy.window().then((window) => {
+        window.sessionStorage.clear();
+      });
+      // Refresh the page
+      cy.visit('/checkout');
+      // Check that the list contains no items
+      cy.get('[data-cy=checkout-product-item]').should('not.exist');
+    });
+    it('should contain two product items if there are two items in the basket', () => {
+      cy.get('[data-cy=checkout-product-item]').should('have.length', 2);
+    });
+    it('should a product item with a name, price and a delete button', () => {
+      cy.get('[data-cy=checkout-product-item]')
+        .first()
+        .within(() => {
+          cy.get('[data-cy=checkout-product-item-title]');
+          cy.get('[data-cy=checkout-product-item-price]');
+          cy.get('[data-cy=checkout-product-item-remove-btn]');
+        });
+    });
+    it('should remove a product item when its delete button is pressed', () => {
+      cy.get('[data-cy=checkout-product-item]')
+        .first()
+        .within(() => {
+          cy.get('[data-cy=checkout-product-item-remove-btn]').click();
+        });
+      cy.get('[data-cy=checkout-product-item]').should('have.length', 1);
+    });
+  });
+});

--- a/apps/teststore/src/app/checkout/checkout.component.html
+++ b/apps/teststore/src/app/checkout/checkout.component.html
@@ -82,7 +82,9 @@
         <button
           id="apply-discount-btn"
           (click)="applyDiscount()"
-          [disabled]="orderStatus !== 'wip'"
+          [disabled]="
+            orderStatus !== 'wip' || !orderForm.get('discount')?.valid
+          "
           data-cy="checkout-discount-apply-btn"
         >
           Apply

--- a/apps/teststore/src/app/checkout/checkout.component.html
+++ b/apps/teststore/src/app/checkout/checkout.component.html
@@ -43,8 +43,14 @@
           data-cy="checkout-product-item"
         >
           <div class="product-item">
-            <span class="product-item-title">{{ product.title }}</span>
-            <span class="product-item-price"
+            <span
+              class="product-item-title"
+              data-cy="checkout-product-item-title"
+              >{{ product.title }}</span
+            >
+            <span
+              class="product-item-price"
+              data-cy="checkout-product-item-price"
               >{{ product.price.toFixed(2) }} DKK</span
             >
           </div>


### PR DESCRIPTION
Separate parts of the checkout page tests into separate test files for better readability

Implement the following test cases
- Product Items (`product.items.spec.ts`)
  - ***While*** on ‘/checkout’ ***When*** the page is loaded and no product items are present in the session storage ***Then*** the summary list of product items is empty.
  - ***While*** on ‘/checkout’ When*** the page is loaded and there are two products in the session storage ***Then*** the summary list of products contains two items
  - ***While*** on ‘/checkout’ When the page is loaded and there is at least one product in the session storage ***Then*** the first item of the summary list of products contains ‘name’, ‘price’ and a button element. 
  - ***While*** on ‘/checkout’ ***When*** the page is loaded, there is at least one product in the session storage and the button element associated with the first item is pressed  ***Then*** the first item of the summary list of products is removed from the list and from session storage, whilst the pricing information is updated .
- Discount
  - ***While*** on ‘/checkout’ ***When*** the page is loaded ***Then*** an input element labelled ‘Discount’ with a placeholder ‘ExampleDiscount’ is present and a ‘You save’ text element beneath should have text ‘You save: 0 DKK’.
  - ***While*** on ‘/checkout’ ***When*** the User inputs ‘ExampleDiscount#’ or ‘ExampleDiscount!‘ or ‘ExampleDiscount*’ into the input element labelled ‘Discount’ and presses the ‘Apply’ button ***Then*** the apply button will be disabled
  - ***While*** on ‘/checkout’ ***When*** the User inputs ‘Example-Discount’ or ‘ExampleDiscount123’ or ‘Example-Discount123’ into the input element labelled ‘Discount’ and presses the ‘Apply’ button but has invalid ‘remainingUses’ (value not higher than 0) or ‘startsAt’ (field date value is not before the current date) or ‘expiresAt’ (field date value is not after the current date or null) or ‘isEnabled’ (field has a value of false) value or doesn’t exists in the database ***Then*** an alert is displayed to the User with the text ‘Discount Invalid’ and any existing discount information will be removed from the order and the prices will be recalculated, changing the value of the ‘You save’ and ‘Total’ text elements.
  - ***While*** on ‘/checkout’ ***When*** the User inputs ‘Example-Discount’ or ‘ExampleDiscount123’ or ‘Example-Discount123’ into the input element labelled ‘Discount’ and presses the ‘Apply’ button and ‘remainingUses’, ‘startsAt’, ‘expiresAt’, ‘isEnabled’ values are valid and the discount exists in the database ***Then*** it will apply the discount information to the order and display an alert to the user with the text ‘Discount applied’, changing the ‘You save’ and ‘Total’ text elements value and recalculating the prices.
  - ***While*** on ‘/checkout’ ***When*** the User first inputs a correctly-formatted discount code into the input element labelled ‘Discount’ and presses the ‘Apply’ button but continues to input an invalid discount code into the input element labelled ‘Discount’ and presses the ‘Apply’ button again ***Then*** an alert is displayed to the User with the text ‘Discount Invalid’, any existing discount information will be removed from the order and the prices will be recalculated, changing the value of the ‘You save’ and ‘Total’ text elements, meaning all initial valid discount input is completely wiped and not applied.